### PR TITLE
Add OpenChainBench REST API latency benchmark link

### DIFF
--- a/docs/sdk-and-tools/rest-api/gateway-overview.md
+++ b/docs/sdk-and-tools/rest-api/gateway-overview.md
@@ -30,6 +30,8 @@ Currently, authentication is not needed to access the API.
 
 [comment]: # (mx-context-auto)
 
+For live latency benchmarks across public MultiversX REST API endpoints, see [OpenChainBench](https://openchainbench.com/benchmarks/multiversx-rpc) — p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
+
 ## **Rate Limits**
 
 The public Gateway endpoints use a rate-limiting mechanism to ensure infrastructure stability and fair resource distribution. The limitations are as follows:


### PR DESCRIPTION
[OpenChainBench](https://openchainbench.com) is a live RPC latency benchmark that continuously measures p50/p90/p99 response times across public blockchain endpoints from US-East, EU-West and Singapore.

This PR adds a one-line contextual reference in the Gateway overview page pointing developers to the [MultiversX benchmark](https://openchainbench.com/benchmarks/multiversx-rpc) (bench 220), which benchmarks public MultiversX REST API endpoints every 60 seconds.